### PR TITLE
Update git commit SHA in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ probably wish to put it in a `dev` or `test` alias. For example:
 ```clojure
 :aliases {:dev {:extra-paths ["test"]
                 :extra-deps {com.cognitect/test-runner {:git/url "git@github.com:cognitect-labs/test-runner"
-                                                        :sha "e3e4ce3d7e29349eeff44afd654bc2de6d5f3ae5"}}}}
+                                                        :sha "5fb4fc46ad0bf2e0ce45eba5b9117a2e89166479"}}}}
 ```
 
 Then, invoke Clojure via the command line, passing


### PR DESCRIPTION
I noticed that when I was following the instructions in the README, `-m cognitect.test-runner` wasn't working because that namespace could not be found. I think that's because the git SHA referenced in the deps.edn setup in the README (e3e4ce3d7e29349eeff44afd654bc2de6d5f3ae5) is a commit prior to [this commit that changed the namespace name](https://github.com/levand/test-runner/commit/5fb4fc46ad0bf2e0ce45eba5b9117a2e89166479), so as of that commit, you would need to use `-m net.vanderhart.test-runner`.